### PR TITLE
Add comment about menu item "context"

### DIFF
--- a/src/Samples/Menu/Menu.ts
+++ b/src/Samples/Menu/Menu.ts
@@ -1,16 +1,46 @@
 import "es6-promise/auto";
+
 import * as SDK from "azure-devops-extension-sdk";
-import { CommonServiceIds, getClient, IHostPageLayoutService } from "azure-devops-extension-api";
-import { BuildDefinition, BuildRestClient } from "azure-devops-extension-api/Build";
+
+import {
+  BuildDefinition,
+  BuildRestClient,
+} from "azure-devops-extension-api/Build";
+import {
+  CommonServiceIds,
+  IHostPageLayoutService,
+  getClient,
+} from "azure-devops-extension-api";
 
 SDK.register("sample-build-menu", () => {
-    return {
-        execute: async (context: BuildDefinition) => {
-            const result = await getClient(BuildRestClient).getDefinition(context.project.id, context.id, undefined, undefined, undefined, true);
-            const dialogSvc = await SDK.getService<IHostPageLayoutService>(CommonServiceIds.HostPageLayoutService);
-            dialogSvc.openMessageDialog(`Fetched build definition ${result.name}. Latest build: ${JSON.stringify(result.latestBuild)}`, { showCancel: false });
-        }
-    }
+  return {
+    /**
+     * Based on the target of the menu item, context can contain relevant data from the initial page the menu was accessed from
+     *
+     * Example: When targeting Azure Repos menu (ms.vss-code-web.source-item-menu), context will contain the following properties:
+     *  - gitRepository: The currently selected git repository
+     *  - version: The currently selected branch
+     */
+    execute: async (context: BuildDefinition) => {
+      const result = await getClient(BuildRestClient).getDefinition(
+        context.project.id,
+        context.id,
+        undefined,
+        undefined,
+        undefined,
+        true
+      );
+      const dialogSvc = await SDK.getService<IHostPageLayoutService>(
+        CommonServiceIds.HostPageLayoutService
+      );
+      dialogSvc.openMessageDialog(
+        `Fetched build definition ${
+          result.name
+        }. Latest build: ${JSON.stringify(result.latestBuild)}`,
+        { showCancel: false }
+      );
+    },
+  };
 });
 
 SDK.init();


### PR DESCRIPTION
I am working on integrating into the Azure Repos view with a menu contribution point. I struggled for a while to figure out how to retrieve the currently selected branch from the main page. Ended up figuring it out and wanted to contribute back with a comment describing that the context parameter can have additional information about the original page the menu was accessed from 

(This is my first PR into this repo, said I didn't have push writes so created a fork, let me know if that is incorrect)