### PR TITLE
Add 'npm install' to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Some external dependencies:
 
 Just run:
 
+    npm install
     npm run build
 
 This produces a .vsix file which can be uploaded to the [Visual Studio Marketplace](https://marketplace.visualstudio.com/azuredevops)


### PR DESCRIPTION
As mentioned in this issue: https://github.com/microsoft/azure-devops-extension-sample/issues/35, running 'npm install' is necessary when building the repo. Took me 20 mins to figure out being new to this area so I think it'd be good to add to the README.md